### PR TITLE
urlencode the key

### DIFF
--- a/js/skactivater.js
+++ b/js/skactivater.js
@@ -1,6 +1,6 @@
 function activatekey(info,tab) {
   chrome.tabs.create({
-    url: "https://store.steampowered.com/account/registerkey?key=" + info.selectionText.replace(/\s/g,'')}, function(tab) {
+    url: "https://store.steampowered.com/account/registerkey?key=" + encodeURIComponent(info.selectionText.replace(/\s/g,''))}, function(tab) {
     chrome.tabs.executeScript(tab.id, {file: 'js/automate.js'});
   });
 };


### PR DESCRIPTION
without properly encoding the key, if the key contains `&` or `=` or ^ or ÆØÅ or a bunch of other characters, you'll send the wrong key. meanwhile, with proper url encoding, the key is binary safe.